### PR TITLE
fix: simplified types for base libraries. add use authorize hook

### DIFF
--- a/src/api/use-authorize.tsx
+++ b/src/api/use-authorize.tsx
@@ -1,0 +1,5 @@
+import { AugmentedMutationResult, useMutation } from "base/use-mutation";
+
+export const useAuthorize = (): AugmentedMutationResult<"authorize"> => {
+    return useMutation({ name: "authorize" });
+};

--- a/src/base/use-mutation.tsx
+++ b/src/base/use-mutation.tsx
@@ -2,17 +2,23 @@ import { TSocketEndpointNames, TSocketError, TSocketRequestPayload, TSocketRespo
 import { useAPI } from "./use-api";
 import { UseMutationOptions, UseMutationResult, useMutation as useReactQueryMutation } from "@tanstack/react-query";
 
-type TSocketRequestMutation<T extends TSocketEndpointNames> = {
+export type AugmentedMutationResult<T extends TSocketEndpointNames> = UseMutationResult<
+    TSocketResponseData<T>,
+    TSocketError<T>,
+    TSocketRequestPayload<T>
+>;
+
+export type AugmentedMutationOptions<T extends TSocketEndpointNames> = {
     name: T;
 } & UseMutationOptions<TSocketResponseData<T>, TSocketError<T>, TSocketRequestPayload<T>>;
 
 export const useMutation = <T extends TSocketEndpointNames>({
     name,
     ...options
-}: TSocketRequestMutation<T>): UseMutationResult<TSocketResponseData<T>, TSocketError<T>, TSocketRequestPayload<T>> => {
+}: AugmentedMutationOptions<T>): AugmentedMutationResult<T> => {
     const { send } = useAPI();
 
-    return useReactQueryMutation<TSocketResponseData<T>, TSocketError<T>, TSocketRequestPayload<T>>({
+    return useReactQueryMutation({
         mutationFn: (payload) => send(name, payload),
         ...options,
     });

--- a/src/base/use-query.tsx
+++ b/src/base/use-query.tsx
@@ -2,7 +2,7 @@ import { useQuery as _useQuery, UseQueryResult, UseQueryOptions } from "@tanstac
 import { TSocketEndpointNames, TSocketError, TSocketRequestPayload, TSocketResponseData } from "../types/api.types";
 import { useAPI } from "./use-api";
 
-type TSocketRequestQuery<T extends TSocketEndpointNames> = {
+export type TSocketRequestQuery<T extends TSocketEndpointNames> = {
     name: T;
     payload?: TSocketRequestPayload<T>;
 } & UseQueryOptions<TSocketResponseData<T>, TSocketError<T>>;


### PR DESCRIPTION
## Description
- Created type utils to simplify typescript types
- Refers generic types from react-query for type portability (to get it emitted properly)
- Add `useAuthorize()` hook