### PR TITLE
chore: add useP2PAdvertInfo and useP2PAdvertiserCreate hooks

### DIFF
--- a/src/api/authorize/index.tsx
+++ b/src/api/authorize/index.tsx
@@ -23,6 +23,8 @@ import { useMt5PasswordCheck } from './use-mt5-password-check';
 import { useOauthApps } from './use-oauth-apps';
 import { useP2pAdvertList } from './use-p2p-advert-list';
 import { useP2pAdvertiserAdverts } from './use-p2p-advertiser-adverts';
+import { useP2PAdvertInfo } from './use-p2p-advert-info';
+import { useP2PAdvertiserCreate } from './use-p2p-advertiser-create';
 import { useP2pAdvertiserList } from './use-p2p-advertiser-list';
 import { useP2pAdvertiserPaymentMethods } from './use-p2p-advertiser-payment-methods';
 import { useP2pAdvertiserRelations } from './use-p2p-advertiser-relations';
@@ -68,8 +70,10 @@ export {
     useMt5LoginList,
     useMt5PasswordCheck,
     useOauthApps,
-    useP2pAdvertList,
+    useP2PAdvertInfo,
     useP2pAdvertiserAdverts,
+    useP2PAdvertiserCreate,
+    useP2pAdvertList,
     useP2pAdvertiserList,
     useP2pAdvertiserPaymentMethods,
     useP2pAdvertiserRelations,

--- a/src/api/authorize/use-p2p-advert-info.tsx
+++ b/src/api/authorize/use-p2p-advert-info.tsx
@@ -1,0 +1,11 @@
+import { useAuthorizeQuery } from '../../base';
+import { TSocketQueryOptions } from '../../base/use-query';
+
+export const useP2PAdvertInfo = ({ ...props }: Omit<TSocketQueryOptions<'p2p_advert_info'>, 'name'> = {}) => {
+    const { data, ...rest } = useAuthorizeQuery({ name: 'p2p_advert_info', ...props });
+
+    return {
+        data: data?.p2p_advert_info,
+        ...rest,
+    };
+};

--- a/src/api/authorize/use-p2p-advertiser-create.tsx
+++ b/src/api/authorize/use-p2p-advertiser-create.tsx
@@ -1,0 +1,13 @@
+import { useAuthorizeQuery } from '../../base';
+import { TSocketQueryOptions } from '../../base/use-query';
+
+export const useP2PAdvertiserCreate = ({
+    ...props
+}: Omit<TSocketQueryOptions<'p2p_advertiser_create'>, 'name'> = {}) => {
+    const { data, ...rest } = useAuthorizeQuery({ name: 'p2p_advertiser_create', ...props });
+
+    return {
+        data: data?.p2p_advertiser_create,
+        ...rest,
+    };
+};


### PR DESCRIPTION
Added useP2PAdvertInfo and useP2PAdvertiserCreate

![Screenshot 2024-04-19 at 9 35 24 AM](https://github.com/deriv-com/deriv-api-hooks/assets/104053934/b365ce69-5a33-4438-ab27-bc992b7328ca)
![Screenshot 2024-04-19 at 9 35 52 AM](https://github.com/deriv-com/deriv-api-hooks/assets/104053934/99b626dd-4a6a-460d-b31a-7011046420cf)
