### PR TITLE
[FEQ] Jim/FEQ-2108/add use-p2p-order-create_and_use-p2p-settings

### DIFF
--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -1,3 +1,4 @@
 export * from './authorize';
 export * from './non-authorize';
 export * from './mutation';
+export * from './subscription';

--- a/src/api/mutation/index.tsx
+++ b/src/api/mutation/index.tsx
@@ -41,6 +41,7 @@ import { useP2pChatCreate } from './use-p2p-chat-create';
 import { useP2pOrderCancel } from './use-p2p-order-cancel';
 import { useP2pOrderConfirm } from './use-p2p-order-confirm';
 import { useP2pOrderDispute } from './use-p2p-order-dispute';
+import { useP2POrderCreate } from './use-p2p-order-create';
 import { usePasskeysLogin } from './use-passkeys-login';
 import { usePasskeysRegister } from './use-passkeys-register';
 import { usePasskeysRename } from './use-passkeys-rename';
@@ -68,6 +69,7 @@ import { useTradingPlatformPasswordReset } from './use-trading-platform-password
 import { useTradingPlatformWithdrawal } from './use-trading-platform-withdrawal';
 import { useTransferBetweenAccounts } from './use-transfer-between-accounts';
 import { useUnsubscribeEmail } from './use-unsubscribe-email';
+
 export {
     useAccountClosure,
     useAccountSecurity,
@@ -112,6 +114,7 @@ export {
     useP2pOrderCancel,
     useP2pOrderConfirm,
     useP2pOrderDispute,
+    useP2POrderCreate,
     usePasskeysLogin,
     usePasskeysRegister,
     usePasskeysRename,

--- a/src/api/mutation/use-p2p-order-create.tsx
+++ b/src/api/mutation/use-p2p-order-create.tsx
@@ -1,0 +1,11 @@
+import { useMutation } from '../../base';
+import { AugmentedMutationOptions } from '../../base/use-mutation';
+
+export const useP2POrderCreate = ({ ...props }: Omit<AugmentedMutationOptions<'p2p_order_create'>, 'name'> = {}) => {
+    const { data, ...rest } = useMutation({ name: 'p2p_order_create', ...props });
+
+    return {
+        data: data?.p2p_order_create,
+        ...rest,
+    };
+};

--- a/src/api/subscription/index.ts
+++ b/src/api/subscription/index.ts
@@ -1,0 +1,3 @@
+import { useP2PSettings } from './use-p2p-settings';
+
+export { useP2PSettings };

--- a/src/api/subscription/use-p2p-settings.tsx
+++ b/src/api/subscription/use-p2p-settings.tsx
@@ -1,0 +1,9 @@
+import { useSubscribe } from '../../base';
+
+export const useP2PSettings = () => {
+    const { data, ...rest } = useSubscribe('p2p_settings');
+    return {
+        data: data?.p2p_settings,
+        ...rest,
+    };
+};

--- a/src/types/api.types.ts
+++ b/src/types/api.types.ts
@@ -145,6 +145,8 @@ import type {
     P2PPaymentMethodsResponse,
     P2PPingRequest,
     P2PPingResponse,
+    P2PSettingsRequest,
+    P2PSettingsResponse,
     PaymentAgentCreateRequest,
     PaymentAgentCreateResponse,
     PaymentAgentDetailsRequest,
@@ -1303,6 +1305,10 @@ type TSocketEndpoints = {
     p2p_ping: {
         request: P2PPingRequest;
         response: P2PPingResponse;
+    };
+    p2p_settings: {
+        request: P2PSettingsRequest;
+        response: P2PSettingsResponse;
     };
     payment_methods: {
         request: PaymentMethodsRequest;


### PR DESCRIPTION
## Changes
- Added useP2PSettings hook
- Added useP2POrderCreate hook

<img width="844" alt="p2p-settings" src="https://github.com/deriv-com/deriv-api-hooks/assets/104334373/41f75caf-0c73-4b2f-84aa-5a603a6d6e3d">


<img width="848" alt="use-p2p-order-create" src="https://github.com/deriv-com/deriv-api-hooks/assets/104334373/d3a27d5a-8c75-4d9b-9060-3ed8ce6ee19d">
