### PR TITLE
[FEQ]Jim/FEQ-2110/add use-infinite-query and integrate it into useP2pAdvertiserAdverts and useP2pAdvertList

### DIFF
--- a/src/api/authorize/index.tsx
+++ b/src/api/authorize/index.tsx
@@ -21,8 +21,8 @@ import { useMt5GetSettings } from './use-mt5-get-settings';
 import { useMt5LoginList } from './use-mt5-login-list';
 import { useMt5PasswordCheck } from './use-mt5-password-check';
 import { useOauthApps } from './use-oauth-apps';
-import { useP2pAdvertList } from './use-p2p-advert-list';
-import { useP2pAdvertiserAdverts } from './use-p2p-advertiser-adverts';
+import { useP2PAdvertList } from './use-p2p-advert-list';
+import { useP2PAdvertiserAdverts } from './use-p2p-advertiser-adverts';
 import { useP2PAdvertInfo } from './use-p2p-advert-info';
 import { useP2PAdvertiserCreate } from './use-p2p-advertiser-create';
 import { useP2pAdvertiserList } from './use-p2p-advertiser-list';
@@ -71,9 +71,9 @@ export {
     useMt5PasswordCheck,
     useOauthApps,
     useP2PAdvertInfo,
-    useP2pAdvertiserAdverts,
+    useP2PAdvertiserAdverts,
     useP2PAdvertiserCreate,
-    useP2pAdvertList,
+    useP2PAdvertList,
     useP2pAdvertiserList,
     useP2pAdvertiserPaymentMethods,
     useP2pAdvertiserRelations,

--- a/src/api/authorize/use-p2p-advert-list.tsx
+++ b/src/api/authorize/use-p2p-advert-list.tsx
@@ -2,17 +2,17 @@ import { useMemo } from 'react';
 import { useInfiniteQuery } from '../../base';
 import { TPaginatedQueryOptions } from '../../base/use-infinite-query';
 
-export const useP2PAdvertList = ({ ...props }: Omit<TPaginatedQueryOptions<'p2p_advert_list'>, 'name'> = {}) => {
+export const useP2PAdvertList = ({
+    ...props
+}: Omit<TPaginatedQueryOptions<'p2p_advert_list'>, 'name' | 'getNextPageParam'> = {}) => {
     const { data, fetchNextPage, ...rest } = useInfiniteQuery({
         name: 'p2p_advert_list',
         ...props,
-        getNextPageParam: props.getNextPageParam
-            ? props.getNextPageParam
-            : (lastPage, pages) => {
-                  if (!lastPage?.p2p_advert_list?.list?.length) return;
+        getNextPageParam: (lastPage, pages) => {
+            if (!lastPage?.p2p_advert_list?.list?.length) return;
 
-                  return pages.length;
-              },
+            return pages.length;
+        },
     });
 
     const flattenedData = useMemo(() => {

--- a/src/api/authorize/use-p2p-advert-list.tsx
+++ b/src/api/authorize/use-p2p-advert-list.tsx
@@ -1,9 +1,9 @@
 import { useMemo } from 'react';
-import { useUseInfiniteQuery } from '../../base';
+import { useInfiniteQuery } from '../../base';
 import { TPaginatedQueryOptions } from '../../base/use-infinite-query';
 
-export const useP2pAdvertList = ({ ...props }: Omit<TPaginatedQueryOptions<'p2p_advert_list'>, 'name'> = {}) => {
-    const { data, fetchNextPage, ...rest } = useUseInfiniteQuery({
+export const useP2PAdvertList = ({ ...props }: Omit<TPaginatedQueryOptions<'p2p_advert_list'>, 'name'> = {}) => {
+    const { data, fetchNextPage, ...rest } = useInfiniteQuery({
         name: 'p2p_advert_list',
         ...props,
         getNextPageParam: props.getNextPageParam

--- a/src/api/authorize/use-p2p-advert-list.tsx
+++ b/src/api/authorize/use-p2p-advert-list.tsx
@@ -1,11 +1,29 @@
-import { useAuthorizeQuery } from '../../base';
-import { TSocketQueryOptions } from '../../base/use-query';
+import { useMemo } from 'react';
+import { useUseInfiniteQuery } from '../../base';
+import { TPaginatedQueryOptions } from '../../base/use-infinite-query';
 
-export const useP2pAdvertList = ({ ...props }: Omit<TSocketQueryOptions<'p2p_advert_list'>, 'name'> = {}) => {
-    const { data, ...rest } = useAuthorizeQuery({ name: 'p2p_advert_list', ...props });
+export const useP2pAdvertList = ({ ...props }: Omit<TPaginatedQueryOptions<'p2p_advert_list'>, 'name'> = {}) => {
+    const { data, fetchNextPage, ...rest } = useUseInfiniteQuery({
+        name: 'p2p_advert_list',
+        ...props,
+        getNextPageParam: props.getNextPageParam
+            ? props.getNextPageParam
+            : (lastPage, pages) => {
+                  if (!lastPage?.p2p_advert_list?.list?.length) return;
+
+                  return pages.length;
+              },
+    });
+
+    const flattenedData = useMemo(() => {
+        if (!data?.pages?.length) return;
+
+        return data?.pages?.flatMap(page => page?.p2p_advert_list?.list);
+    }, [data?.pages]);
 
     return {
-        data: data?.p2p_advert_list,
+        data: flattenedData,
+        loadMoreAdverts: fetchNextPage,
         ...rest,
     };
 };

--- a/src/api/authorize/use-p2p-advertiser-adverts.tsx
+++ b/src/api/authorize/use-p2p-advertiser-adverts.tsx
@@ -1,11 +1,11 @@
 import { useMemo } from 'react';
-import { useUseInfiniteQuery } from '../../base';
+import { useInfiniteQuery } from '../../base';
 import { TPaginatedQueryOptions } from '../../base/use-infinite-query';
 
-export const useP2pAdvertiserAdverts = ({
+export const useP2PAdvertiserAdverts = ({
     ...props
 }: Omit<TPaginatedQueryOptions<'p2p_advertiser_adverts'>, 'name'> = {}) => {
-    const { data, fetchNextPage, ...rest } = useUseInfiniteQuery({
+    const { data, fetchNextPage, ...rest } = useInfiniteQuery({
         name: 'p2p_advertiser_adverts',
         ...props,
         getNextPageParam: props.getNextPageParam

--- a/src/api/authorize/use-p2p-advertiser-adverts.tsx
+++ b/src/api/authorize/use-p2p-advertiser-adverts.tsx
@@ -4,17 +4,15 @@ import { TPaginatedQueryOptions } from '../../base/use-infinite-query';
 
 export const useP2PAdvertiserAdverts = ({
     ...props
-}: Omit<TPaginatedQueryOptions<'p2p_advertiser_adverts'>, 'name'> = {}) => {
+}: Omit<TPaginatedQueryOptions<'p2p_advertiser_adverts'>, 'name' | 'getNextPageParam'> = {}) => {
     const { data, fetchNextPage, ...rest } = useInfiniteQuery({
         name: 'p2p_advertiser_adverts',
         ...props,
-        getNextPageParam: props.getNextPageParam
-            ? props.getNextPageParam
-            : (lastPage, pages) => {
-                  if (!lastPage?.p2p_advertiser_adverts?.list?.length) return;
+        getNextPageParam: (lastPage, pages) => {
+            if (!lastPage?.p2p_advertiser_adverts?.list?.length) return;
 
-                  return pages.length;
-              },
+            return pages.length;
+        },
     });
 
     const flattenedData = useMemo(() => {

--- a/src/api/authorize/use-p2p-advertiser-adverts.tsx
+++ b/src/api/authorize/use-p2p-advertiser-adverts.tsx
@@ -1,13 +1,31 @@
-import { useAuthorizeQuery } from '../../base';
-import { TSocketQueryOptions } from '../../base/use-query';
+import { useMemo } from 'react';
+import { useUseInfiniteQuery } from '../../base';
+import { TPaginatedQueryOptions } from '../../base/use-infinite-query';
 
 export const useP2pAdvertiserAdverts = ({
     ...props
-}: Omit<TSocketQueryOptions<'p2p_advertiser_adverts'>, 'name'> = {}) => {
-    const { data, ...rest } = useAuthorizeQuery({ name: 'p2p_advertiser_adverts', ...props });
+}: Omit<TPaginatedQueryOptions<'p2p_advertiser_adverts'>, 'name'> = {}) => {
+    const { data, fetchNextPage, ...rest } = useUseInfiniteQuery({
+        name: 'p2p_advertiser_adverts',
+        ...props,
+        getNextPageParam: props.getNextPageParam
+            ? props.getNextPageParam
+            : (lastPage, pages) => {
+                  if (!lastPage?.p2p_advertiser_adverts?.list?.length) return;
+
+                  return pages.length;
+              },
+    });
+
+    const flattenedData = useMemo(() => {
+        if (!data?.pages?.length) return;
+
+        return data?.pages?.flatMap(page => page?.p2p_advertiser_adverts?.list);
+    }, [data?.pages]);
 
     return {
-        data: data?.p2p_advertiser_adverts,
+        data: flattenedData,
+        loadMoreAdverts: fetchNextPage,
         ...rest,
     };
 };

--- a/src/base/index.ts
+++ b/src/base/index.ts
@@ -3,5 +3,6 @@ import { useAuthorizeQuery } from './use-authorize-query';
 import { useQuery } from './use-query';
 import { useMutation } from './use-mutation';
 import { useSubscribe } from './use-subscribe';
+import { useUseInfiniteQuery } from './use-infinite-query';
 
-export { useAppData, useAuthData, useAuthorizeQuery, useQuery, useMutation, useSubscribe };
+export { useAppData, useAuthData, useAuthorizeQuery, useQuery, useMutation, useSubscribe, useUseInfiniteQuery };

--- a/src/base/index.ts
+++ b/src/base/index.ts
@@ -3,6 +3,6 @@ import { useAuthorizeQuery } from './use-authorize-query';
 import { useQuery } from './use-query';
 import { useMutation } from './use-mutation';
 import { useSubscribe } from './use-subscribe';
-import { useUseInfiniteQuery } from './use-infinite-query';
+import { useInfiniteQuery } from './use-infinite-query';
 
-export { useAppData, useAuthData, useAuthorizeQuery, useQuery, useMutation, useSubscribe, useUseInfiniteQuery };
+export { useAppData, useAuthData, useAuthorizeQuery, useQuery, useMutation, useSubscribe, useInfiniteQuery };

--- a/src/base/use-infinite-query.tsx
+++ b/src/base/use-infinite-query.tsx
@@ -1,0 +1,39 @@
+import { UseInfiniteQueryOptions, useInfiniteQuery as _useInfiniteQuery } from '@tanstack/react-query';
+import {
+    TSocketPaginateableEndpointNames,
+    TSocketError,
+    TSocketRequestPayload,
+    TSocketResponseData,
+} from '../types/api.types';
+import { useAPI, useAuthData } from './use-context-hooks';
+
+export type TPaginatedQueryOptions<T extends TSocketPaginateableEndpointNames> = {
+    name: T;
+    payload?: TSocketRequestPayload<T>;
+    queryKey?: string[];
+} & Partial<Omit<UseInfiniteQueryOptions<TSocketResponseData<T>, TSocketError<T>>, 'queryKey' | 'queryFn' | 'select'>>;
+
+export const useUseInfiniteQuery = <T extends TSocketPaginateableEndpointNames>({
+    name,
+    payload,
+    queryKey,
+    ...options
+}: TPaginatedQueryOptions<T>) => {
+    const { isAuthorized } = useAuthData();
+    const { send } = useAPI();
+    const initialOffset = payload?.offset || 0;
+    const limit = payload?.limit || 50;
+    return _useInfiniteQuery<TSocketResponseData<T>, TSocketError<T>>({
+        queryKey: [name, ...(queryKey ?? [])],
+        queryFn: ({ pageParam = 0 }) =>
+            send(name, {
+                ...payload,
+                limit,
+                offset: Number(pageParam) * limit + initialOffset,
+            } as TSocketRequestPayload<T>),
+        ...options,
+        initialPageParam: options?.initialPageParam ? options.initialPageParam : 0,
+        getNextPageParam: options?.getNextPageParam ? options.getNextPageParam : (_lastPage, pages) => pages.length,
+        enabled: isAuthorized && (options?.enabled === undefined || options.enabled),
+    });
+};

--- a/src/base/use-infinite-query.tsx
+++ b/src/base/use-infinite-query.tsx
@@ -13,7 +13,7 @@ export type TPaginatedQueryOptions<T extends TSocketPaginateableEndpointNames> =
     queryKey?: string[];
 } & Partial<Omit<UseInfiniteQueryOptions<TSocketResponseData<T>, TSocketError<T>>, 'queryKey' | 'queryFn' | 'select'>>;
 
-export const useUseInfiniteQuery = <T extends TSocketPaginateableEndpointNames>({
+export const useInfiniteQuery = <T extends TSocketPaginateableEndpointNames>({
     name,
     payload,
     queryKey,


### PR DESCRIPTION
## Changes
- Added useInfiniteQuery hook
- Added useP2PAdvertList hook
- Added useP2PAdvertiserAdverts hook

<img width="965" alt="useP2pAdvertiserAdverts" src="https://github.com/deriv-com/deriv-api-hooks/assets/104334373/9ad5cc49-a58b-4828-8da9-850c195e9ea2">

<img width="888" alt="useP2pAdvertList" src="https://github.com/deriv-com/deriv-api-hooks/assets/104334373/21aa77d0-90ac-4340-9dff-c0860c68583b">
