### PR TITLE
[FEQ] Jim/FEQ-2111/add use-p2p-advertiser-info

### DIFF
--- a/src/api/subscription/index.ts
+++ b/src/api/subscription/index.ts
@@ -1,3 +1,4 @@
+import { useP2PAdvertiserInfo } from './use-p2p-advertiser-info';
 import { useP2PSettings } from './use-p2p-settings';
 
-export { useP2PSettings };
+export { useP2PAdvertiserInfo, useP2PSettings };

--- a/src/api/subscription/use-p2p-advertiser-info.tsx
+++ b/src/api/subscription/use-p2p-advertiser-info.tsx
@@ -1,0 +1,9 @@
+import { useSubscribe } from '../../base';
+
+export const useP2PAdvertiserInfo = () => {
+    const { data, ...rest } = useSubscribe('p2p_advertiser_info');
+    return {
+        data: data?.p2p_advertiser_info,
+        ...rest,
+    };
+};


### PR DESCRIPTION
## Changes
- Add `useP2PAdvertiserInfo` hook
<img width="941" alt="useP2PAdvertiserInfo_data" src="https://github.com/deriv-com/deriv-api-hooks/assets/104334373/3017363a-cebb-4c70-99af-373cf866b1f5">
<img width="903" alt="useP2PAdvertiserInfo" src="https://github.com/deriv-com/deriv-api-hooks/assets/104334373/a44ff8cc-c4fc-4bf1-9bf3-5bc7a5810a0a">