### PR TITLE
chore: add bypassAuth flag to enable call before authorise

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "description": "A React hooks library utilising Tanstack Query which encapsulates Deriv API WebSocket functionality.",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "prepare": "rm -rf ./dist && npm run build",
         "watch": "tsc && vite build --watch",
         "extract": "tsc ./scripts/codemod.ts --esModuleInterop --outDir ./codemod && mv ./codemod/codemod.js ./codemod/codemod.cjs && node ./codemod/codemod.cjs && prettier ./src/api --write"

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
     "description": "A React hooks library utilising Tanstack Query which encapsulates Deriv API WebSocket functionality.",
     "scripts": {
         "dev": "vite",
-        "build": "vite build",
+        "build": "tsc && vite build",
         "prepare": "rm -rf ./dist && npm run build",
-        "watch": "tsc && vite build --watch",
+        "watch": "vite build --watch",
         "extract": "tsc ./scripts/codemod.ts --esModuleInterop --outDir ./codemod && mv ./codemod/codemod.js ./codemod/codemod.cjs && node ./codemod/codemod.cjs && prettier ./src/api --write"
     },
     "keywords": [

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "dev": "vite",
         "build": "tsc && vite build",
         "prepare": "rm -rf ./dist && npm run build",
-        "watch": "vite build --watch",
+        "watch": "tsc && vite build --watch",
         "extract": "tsc ./scripts/codemod.ts --esModuleInterop --outDir ./codemod && mv ./codemod/codemod.js ./codemod/codemod.cjs && node ./codemod/codemod.cjs && prettier ./src/api --write"
     },
     "keywords": [

--- a/src/base/use-mutation.tsx
+++ b/src/base/use-mutation.tsx
@@ -10,9 +10,14 @@ export type AugmentedMutationResult<T extends TSocketEndpointNames> = UseMutatio
 
 export type AugmentedMutationOptions<T extends TSocketEndpointNames> = {
     name: T;
+    bypassAuth?: boolean;
 } & Omit<UseMutationOptions<TSocketResponseData<T>, TSocketError<T>, TSocketRequestPayload<T>>, 'mutationFn'>;
 
-export const useMutation = <T extends TSocketEndpointNames>({ name, ...options }: AugmentedMutationOptions<T>) => {
+export const useMutation = <T extends TSocketEndpointNames>({
+    name,
+    bypassAuth = false,
+    ...options
+}: AugmentedMutationOptions<T>) => {
     const { isAuthorized } = useAuthData();
     const { send } = useAPI();
 
@@ -23,11 +28,11 @@ export const useMutation = <T extends TSocketEndpointNames>({ name, ...options }
 
     return {
         mutate: (payload: TSocketRequestPayload<T>) => {
-            if (!isAuthorized) return;
+            if (!bypassAuth && !isAuthorized) return;
             return mutate(payload);
         },
         mutateAsync: (payload: TSocketRequestPayload<T>) => {
-            if (!isAuthorized) return;
+            if (!bypassAuth && !isAuthorized) return;
             return mutateAsync(payload);
         },
         ...props,


### PR DESCRIPTION
Add bypassAuth flag to enable api calls like `new_account_virtual` that can be called before authorise