### PR TITLE
fix: fix subscription error

### DIFF
--- a/src/base/use-subscribe.tsx
+++ b/src/base/use-subscribe.tsx
@@ -40,7 +40,7 @@ export const useSubscribe = <T extends TSocketSubscribableEndpointNames>(name: T
         const matchingSubscription = subscriptions.current?.[id];
         if (matchingSubscription) return { id, subscription: matchingSubscription };
 
-        const subscription = derivAPI.current?.subscribe({ [name]: 1, subscribe: 1, ...(payload || {}) });
+        const subscription = derivAPI?.subscribe({ [name]: 1, subscribe: 1, ...(payload || {}) });
         subscriptions.current = { ...(subscriptions.current || {}), ...{ [id]: subscription } };
         return { id, subscription };
     };


### PR DESCRIPTION
## Changes
- Removed the call to `current` property, which doesn't exist on `derivAPI` object. Reference [here](https://github.com/deriv-com/deriv-api/blob/master/src/deriv_api/DerivAPIBasic.js)