### PR TITLE
[FEQ] Jim/FEQ-2143/seperate p2p advertiser payment methods

### DIFF
--- a/src/api/mutation/index.tsx
+++ b/src/api/mutation/index.tsx
@@ -44,6 +44,7 @@ import { useP2pOrderDispute } from './use-p2p-order-dispute';
 import { useP2POrderCreate } from './use-p2p-order-create';
 import { useP2PAdvertiserCreate } from './use-p2p-advertiser-create';
 import { useP2PAdvertiserPaymentMethods } from './use-p2p-advertiser-payment-methods';
+import { useP2PAdvertiserPaymentMethodsMutation } from './use-p2p-advertiser-payment-methods-mutation';
 import { useP2PAdvertiserRelations } from './use-p2p-advertiser-relations';
 import { useP2POrderReview } from './use-p2p-order-review';
 import { usePasskeysLogin } from './use-passkeys-login';
@@ -123,6 +124,7 @@ export {
     useP2POrderCreate,
     useP2PAdvertiserCreate,
     useP2PAdvertiserPaymentMethods,
+    useP2PAdvertiserPaymentMethodsMutation,
     useP2PAdvertiserRelations,
     useP2POrderReview,
     usePasskeysLogin,

--- a/src/api/mutation/use-p2p-advertiser-payment-methods-mutation.tsx
+++ b/src/api/mutation/use-p2p-advertiser-payment-methods-mutation.tsx
@@ -1,0 +1,13 @@
+import { useMutation } from '../../base';
+import { AugmentedMutationOptions } from '../../base/use-mutation';
+
+export const useP2PAdvertiserPaymentMethodsMutation = ({
+    ...props
+}: Omit<AugmentedMutationOptions<'p2p_advertiser_payment_methods'>, 'name'> = {}) => {
+    const { data, ...rest } = useMutation({ name: 'p2p_advertiser_payment_methods', ...props });
+
+    return {
+        data: data?.p2p_advertiser_payment_methods,
+        ...rest,
+    };
+};

--- a/src/api/mutation/use-p2p-advertiser-payment-methods.tsx
+++ b/src/api/mutation/use-p2p-advertiser-payment-methods.tsx
@@ -1,10 +1,10 @@
-import { useMutation } from '../../base';
-import { AugmentedMutationOptions } from '../../base/use-mutation';
+import { useAuthorizeQuery } from '../../base';
+import { TSocketQueryOptions } from '../../base/use-query';
 
 export const useP2PAdvertiserPaymentMethods = ({
     ...props
-}: Omit<AugmentedMutationOptions<'p2p_advertiser_payment_methods'>, 'name'> = {}) => {
-    const { data, ...rest } = useMutation({ name: 'p2p_advertiser_payment_methods', ...props });
+}: Omit<TSocketQueryOptions<'p2p_advertiser_payment_methods'>, 'name'> = {}) => {
+    const { data, ...rest } = useAuthorizeQuery({ name: 'p2p_advertiser_payment_methods', ...props });
 
     return {
         data: data?.p2p_advertiser_payment_methods,


### PR DESCRIPTION
## Change
- Created separate hooks for `mutation` and `non-mutation` queries for the endpoint. i.e. (`useP2PAdvertiserPaymentMethods`, and `useP2PAdvertiserPaymentMethodsMutation `)
- Added hint for `major` version bump to be used for breaking changes