### PR TITLE
ci: bump deriv-utils version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.0.0-development",
             "license": "ISC",
             "dependencies": {
-                "@deriv-com/utils": "^0.0.25",
+                "@deriv-com/utils": "^0.0.26",
                 "@deriv/api-types": "^1.0.667",
                 "@deriv/deriv-api": "^1.0.15",
                 "@tanstack/react-query": "^5.40.0",
@@ -387,9 +387,9 @@
             }
         },
         "node_modules/@deriv-com/utils": {
-            "version": "0.0.25",
-            "resolved": "https://registry.npmjs.org/@deriv-com/utils/-/utils-0.0.25.tgz",
-            "integrity": "sha512-zIJLDHgc8Aja+u8YDZ0FVNbMX8DQB3T+ioRzwIj8SevEo/VDEke1IUMxJe5PXCHYNs7ml2mB/mXSfLOr7KGqdA=="
+            "version": "0.0.26",
+            "resolved": "https://registry.npmjs.org/@deriv-com/utils/-/utils-0.0.26.tgz",
+            "integrity": "sha512-5LyGtXewkUJasOiVL1BEUiAH6iAWa8OxcgGawFob55uXRX5xfCbyN2txDyfZaLNsM7lh6xRWGnseHARKBrqZpw=="
         },
         "node_modules/@deriv/api-types": {
             "version": "1.0.731",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "homepage": "https://deriv.com",
     "license": "ISC",
     "dependencies": {
-        "@deriv-com/utils": "^0.0.25",
+        "@deriv-com/utils": "^0.0.26",
         "@deriv/api-types": "^1.0.667",
         "@deriv/deriv-api": "^1.0.15",
         "@tanstack/react-query": "^5.40.0",


### PR DESCRIPTION
changes: 
- updated `deriv-utils` to version `0.0.26`