### PR TITLE
chore: added fallback to accountList inside auth-context

### DIFF
--- a/src/context/auth-context.tsx
+++ b/src/context/auth-context.tsx
@@ -29,7 +29,9 @@ export const AuthDataProvider = ({ children }: AuthDataProviderProps) => {
 
     const { mutateAsync: requestLogout } = useLogout();
 
-    const accountsList: Record<string, string> = JSON.parse(localStorage.getItem('client.accounts') ?? '{}');
+    const accountsList: Record<string, string> = JSON.parse(
+        localStorage.getItem('client.accounts') ?? localStorage.getItem('accountsList') ?? '{}'
+    );
 
     const isAuthorized = useMemo(
         () => isSuccess && (!!activeLoginid || !!Object.keys(accountsList).length),


### PR DESCRIPTION
## Motivation
fix switch account issue in api.deriv.com

## changes:
- added fallback to `accountList` key name inside localStorage if the `client.accounts` key doesn't exist