### PR TITLE
Improve `isSocketClosingOrClosed` Check to Handle `WebSocket.CONNECTING` State

### DIFF
--- a/src/client-library/deriv-api-client.ts
+++ b/src/client-library/deriv-api-client.ts
@@ -274,12 +274,12 @@ export class DerivAPIClient {
         await this.reinitializeData(this.subscribeHandler, this.authorizePayload);
     }
 
-    isSocketClosingOrClosed() {
-        return ![2, 3].includes(this.websocket.readyState);
+    isSocketReadyForSending() {
+        return this.websocket.readyState === WebSocket.OPEN; // 1
     }
 
     disconnect() {
-        if (!this.isSocketClosingOrClosed()) {
+        if (!this.isSocketReadyForSending()) {
             this.websocket.close();
         }
     }


### PR DESCRIPTION
## Description:
In the current implementation of the isSocketClosingOrClosed method, the state of the WebSocket connection is checked using the following [logic](https://github.com/deriv-com/deriv-api-hooks/blob/dac497b6d18b6ca9d706a49b0dde14537cc27b64/src/client-library/deriv-api-client.ts#L278):

```javascript
isSocketClosingOrClosed() {
    return ![2, 3].includes(this.websocket.readyState);
}
```

This condition currently checks if the WebSocket connection is in the CLOSED (3) or CLOSING (2) states but does not handle the CONNECTING (0) state. As a result, if send is called while the WebSocket is still in the `CONNECTING` state, it may throw an error.


## Suggested Improvement:
To enhance robustness, updating the condition to explicitly account for the `CONNECTING` state as follows:
```javascript
isSocketReadyForSending() {
    return this.websocket.readyState === WebSocket.OPEN; // 1
}
```

This modification would prevent sending messages when the WebSocket is not fully open, reducing the likelihood of encountering runtime errors and improving the overall stability of the application.
