### PR TITLE
Ameerul / PLA-1882 Account Switching Across Tabs

### DIFF
--- a/src/context/app-data-context.tsx
+++ b/src/context/app-data-context.tsx
@@ -13,14 +13,18 @@ type AppData = {
 
 export const AppDataContext = createContext<AppData | null>(null);
 
+type AppDataProviderProps = PropsWithChildren & { accountType?: string; currency?: string };
+
 /**
  * By design, this is the only provider that should be exported out.
  * Absrtracts out the sequence of the providers.
  *
+ * @param {string} accountType - The desired account type tied to the login ID eg. CR, VRTC, MF, etc.
+ * @param {string} currency - The desired currency tied to the login ID, eg. USD, EUR, BTC etc.
  * @param {PropsWithChildren} { children } - The child components to be wrapped by the provider.
  * @returns {JSX.Element} The provider component wrapping its children with App data context.
  */
-export const AppDataProvider = ({ children }: PropsWithChildren) => {
+export const AppDataProvider = ({ accountType = '', children, currency = '' }: AppDataProviderProps) => {
     const [activeLoginid, setActiveLoginid] = useState('');
     const [environment, setEnvironment] = useState<Environment>('demo');
 
@@ -32,7 +36,9 @@ export const AppDataProvider = ({ children }: PropsWithChildren) => {
     return (
         <AppDataContext.Provider value={value}>
             <APIProvider>
-                <AuthDataProvider>{children}</AuthDataProvider>
+                <AuthDataProvider accountType={accountType} currency={currency}>
+                    {children}
+                </AuthDataProvider>
             </APIProvider>
         </AppDataContext.Provider>
     );

--- a/src/context/auth-context.tsx
+++ b/src/context/auth-context.tsx
@@ -13,16 +13,18 @@ type AuthData = {
     appendAccountLocalStorage: (loginid: string, token: string) => void;
     logout: () => void;
     error: TSocketError<'authorize'>['error'] | null;
-    data: TSocketResponseData<"authorize"> | undefined
+    data: TSocketResponseData<'authorize'> | undefined;
 };
 
 export const AuthDataContext = createContext<AuthData | null>(null);
 
 type AuthDataProviderProps = {
+    accountType: string;
     children: ReactNode;
+    currency: string;
 };
 
-export const AuthDataProvider = ({ children }: AuthDataProviderProps) => {
+export const AuthDataProvider = ({ accountType = '', children, currency = '' }: AuthDataProviderProps) => {
     const { activeLoginid, setActiveLoginid } = useAppData();
     const { loginInfo, paramsToDelete } = URLUtils.getLoginInfoFromURL();
 
@@ -33,6 +35,10 @@ export const AuthDataProvider = ({ children }: AuthDataProviderProps) => {
     const accountsList: Record<string, string> = JSON.parse(
         localStorage.getItem('client.accounts') ?? localStorage.getItem('accountsList') ?? '{}'
     );
+
+    const getAccountWithCurrency = useCallback(() => {
+        return loginInfo.find(account => account.currency === currency && account.loginid.includes(accountType));
+    }, [loginInfo]);
 
     const isAuthorized = useMemo(
         () => isSuccess && (!!activeLoginid || !!Object.keys(accountsList).length),
@@ -70,8 +76,14 @@ export const AuthDataProvider = ({ children }: AuthDataProviderProps) => {
         if (loginInfo.length) {
             const defaultActiveAccount = URLUtils.getDefaultActiveAccount(loginInfo);
             if (!defaultActiveAccount) return;
+            const hasAccountWithCurrency = currency && getAccountWithCurrency();
 
-            setActiveLoginid(loginInfo[0].loginid);
+            if (hasAccountWithCurrency) {
+                setActiveLoginid(getAccountWithCurrency()?.loginid ?? '');
+            } else {
+                setActiveLoginid(loginInfo[0].loginid);
+            }
+
             const accountsList: Record<string, string> = {};
 
             loginInfo.forEach(account => {
@@ -82,9 +94,13 @@ export const AuthDataProvider = ({ children }: AuthDataProviderProps) => {
 
             URLUtils.filterSearchParams(paramsToDelete);
 
-            authorizeAccount(loginInfo[0].token);
-
-            localStorage.setItem('authToken', loginInfo[0].token);
+            if (hasAccountWithCurrency) {
+                authorizeAccount(getAccountWithCurrency()?.token ?? '');
+                localStorage.setItem('authToken', getAccountWithCurrency()?.token ?? '');
+            } else {
+                authorizeAccount(loginInfo[0].token);
+                localStorage.setItem('authToken', loginInfo[0].token);
+            }
         } else {
             const token = localStorage.getItem('authToken');
 
@@ -120,7 +136,7 @@ export const AuthDataProvider = ({ children }: AuthDataProviderProps) => {
             appendAccountLocalStorage,
             logout,
             isAuthorized,
-            data
+            data,
         }),
         [activeLoginid, isSuccess, error, status]
     );


### PR DESCRIPTION
- Added new props to AppDataProvider and AuthContext (currency + accountType)
- Using those props, it will check the account list when the user logs in, if it includes the account type 'CR' and the currency is USD, it will return the first item it finds in that list and use the authtoken from it to authorize.


https://github.com/user-attachments/assets/9e05f972-526c-4116-a322-8002fad9aec3

